### PR TITLE
Remapping cp932 to windows-31j

### DIFF
--- a/lib/codepages.tsv
+++ b/lib/codepages.tsv
@@ -25,7 +25,7 @@
 870	IBM870	IBM EBCDIC Multilingual/ROECE (Latin 2); IBM EBCDIC Multilingual Latin 2
 874	windows-874	ANSI/OEM Thai (same as 28605, ISO 8859-15); Thai (Windows)
 875	cp875	IBM EBCDIC Greek Modern
-932	shift_jis	ANSI/OEM Japanese; Japanese (Shift-JIS)
+932	windows-31j	ANSI/OEM Japanese; Japanese (Windows-31J; superset of Shift-JIS)
 936	gb2312	ANSI/OEM Simplified Chinese (PRC, Singapore); Chinese Simplified (GB2312)
 949	ks_c_5601-1987	ANSI/OEM Korean (Unified Hangul Code)
 950	big5	ANSI/OEM Traditional Chinese (Taiwan; Hong Kong SAR, PRC); Chinese Traditional (Big5)


### PR DESCRIPTION
Remaps CP932 to Microsoft's extension of Shift_JIS to include NEC character sets and other non-standard stuff.

Might be worth double-checking 936, 949 and 950 too but I have a lot less experience with any of those.

Fixes #2.
